### PR TITLE
Db

### DIFF
--- a/src/db/db.module.ts
+++ b/src/db/db.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { DbService } from './db.service';
+
+@Global()
+@Module({
+  providers: [DbService],
+  exports: [DbService],
+})
+export class DbModule {}

--- a/src/db/db.service.ts
+++ b/src/db/db.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaClient } from '../../generated/prisma';
+
+@Injectable()
+export class DbService extends PrismaClient {
+  constructor(config: ConfigService) {
+    super({
+      datasources: {
+        db: {
+          url: config.get('DATABASE_URL'),
+        },
+      },
+    });
+  }
+
+  async cleanDb() {
+    return this.$transaction([
+      this.bookmark.deleteMany(),
+      this.user.deleteMany(),
+    ]);
+  }
+}


### PR DESCRIPTION
Adds a DbService extending PrismaClient with a cleanDb method to execute transactional deletions.
Creates a global DbModule that provides and exports the DbService.